### PR TITLE
Melhorar a estrutura de testes de dependências em futuros releases, evitando que muitos erros só apareçam quando é lançado o release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,19 @@ cache:
   directories:
   - eggs
   - parts/node
+env:
+  matrix:
+    - MASTER=true
+    - PENDING_RELEASE=true
 matrix:
+  allow_failures:
+    - env: MASTER=true
   fast_finish: true
 install:
+- test $MASTER && sed -ie '/https:\/\/raw\.githubusercontent\.com\/plonegovbr\/portal\.buildout\/master\/buildout\.d\/versions\.cfg/d' buildout.cfg || true
 - python bootstrap.py
 - bin/buildout annotate
-- bin/buildout -Nq
+- bin/buildout
 before_script:
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -2,9 +2,8 @@
 extends =
     https://raw.github.com/collective/buildout.plonetest/master/test-4.3.x.cfg
     https://raw.github.com/collective/buildout.plonetest/master/qa.cfg
-    https://raw.githubusercontent.com/plonegovbr/portalpadrao.release/master/1.0.5/versions.cfg
-    https://raw.githubusercontent.com/plonegovbr/portal.buildout/master/buildout.d/versions.cfg
     https://raw.githubusercontent.com/plone/plone.app.robotframework/master/versions.cfg
+    https://raw.githubusercontent.com/plonegovbr/portal.buildout/master/buildout.d/versions.cfg
 
 package-name = brasil.gov.paginadestaque
 package-extras = [test]


### PR DESCRIPTION
Pacotes plonegovbr deveriam ter mais de um job de testes : plonegovbr/portalpadrao.release#11