### PR TITLE
Atualiza .coveragerc para só pegar arquivos relevantes.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,8 +1,6 @@
 [report]
+include =
+    src/brasil/gov/paginadestaque/*
 omit =
-    /home/*/.buildout/eggs/*
-    /usr/*
-    bin/test
-    buildout-cache/eggs/*
-    eggs/*
-    parts/*
+    */test*
+    */upgrades/*


### PR DESCRIPTION
Durante a demanda de dois jobs em https://github.com/plonegovbr/brasil.gov.paginadestaque/commit/626688606e62662164a4c7e502da9e519ebcb448, o coverage tinha piorado.